### PR TITLE
IE11 compat, fix unpersisted event

### DIFF
--- a/packages/forms/package-lock.json
+++ b/packages/forms/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@truework/forms",
-  "version": "0.8.0",
+  "version": "0.8.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/forms/package-lock.json
+++ b/packages/forms/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@truework/forms",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@truework/forms",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/forms/src/SSNInput.tsx
+++ b/packages/forms/src/SSNInput.tsx
@@ -24,6 +24,8 @@ export function SSNInput(props: SSNInputProps) {
 
   const onChange = React.useCallback(
     (e) => {
+      e.persist()
+
       const val = clean(e.target.value, '*'); // no formatting
       const prev = clean(raw); // no formatting
 
@@ -39,7 +41,10 @@ export function SSNInput(props: SSNInputProps) {
   );
 
   const resetCursor = React.useCallback((e) => {
+    e.persist()
+
     const len = e.target.value.length;
+
     e.target.setSelectionRange(len, len);
   }, []);
 
@@ -55,7 +60,6 @@ export function SSNInput(props: SSNInputProps) {
       onFocus={resetCursor}
       onKeyUp={resetCursor}
       onKeyDown={resetCursor}
-      onBlur={resetCursor}
       onClick={resetCursor}
     />
   );


### PR DESCRIPTION
The `onBlur` in this case was preventing leaving the input on IE11. Separately, we also need to persist this event.