### PR TITLE
Fixes #6 Prevent button colors from being overwritten

### DIFF
--- a/packages/ui/src/Alert/stories.tsx
+++ b/packages/ui/src/Alert/stories.tsx
@@ -46,7 +46,7 @@ storiesOf('Alerts', module).add('All', () => (
     <Alert appearance="primary" type="success" mb="sm">
       Great job! This is a success message.
     </Alert>
-    <Alert appearance="primary" type="error" icon={<Icon name="AlertCircle" />}>
+    <Alert appearance="primary" type="error" icon={<Icon name="AlertCircle" />} mb="sm">
       <Box display="flex" justifyContent="space-between" alignItems="center">
         <p>
           Please help us with your request by answering the required questions.
@@ -56,5 +56,23 @@ storiesOf('Alerts', module).add('All', () => (
         </Button>
       </Box>
     </Alert>
+
+    <GridRow gutter="sm">
+      <GridItem width={[1, 1, 1, 1]}>
+        <Alert
+          appearance="primary"
+          type="primary"
+          mb="sm"
+          icon={<Icon name="FileText" />}
+        >
+          <Box display="flex" alignItems="center" justifyContent="space-between">
+            You have a reverification request.
+            <Button as="a" href="#" appearance="tertiary" size="small">
+              View Reverification
+            </Button>
+          </Box>
+        </Alert>
+      </GridItem>
+    </GridRow>
   </Box>
 ));

--- a/packages/ui/src/Alert/stories.tsx
+++ b/packages/ui/src/Alert/stories.tsx
@@ -57,22 +57,18 @@ storiesOf('Alerts', module).add('All', () => (
       </Box>
     </Alert>
 
-    <GridRow gutter="sm">
-      <GridItem width={[1, 1, 1, 1]}>
-        <Alert
-          appearance="primary"
-          type="primary"
-          mb="sm"
-          icon={<Icon name="FileText" />}
-        >
-          <Box display="flex" alignItems="center" justifyContent="space-between">
-            You have a reverification request.
-            <Button as="a" href="#" appearance="tertiary" size="small">
-              View Reverification
-            </Button>
-          </Box>
-        </Alert>
-      </GridItem>
-    </GridRow>
+    <Alert
+      appearance="primary"
+      type="primary"
+      mb="sm"
+      icon={<Icon name="FileText" />}
+    >
+      <Box display="flex" alignItems="center" justifyContent="space-between">
+        You have a reverification request.
+        <Button as="a" href="#" appearance="tertiary" size="small">
+          View Reverification
+        </Button>
+      </Box>
+    </Alert>
   </Box>
 ));

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -71,7 +71,7 @@ const appearance = variant({
     primary: {
       ...sharedAppearance,
       bg: 'primary',
-      color: 'white',
+      color: 'white !important',
       border: '1px solid #353CCC',
       ':hover, :focus, :active': {
         outline: 0,
@@ -83,7 +83,7 @@ const appearance = variant({
     secondary: {
       ...sharedAppearance,
       bg: 'white',
-      color: 'secondary',
+      color: `${theme.colors.secondary} !important`,
       border: 'outline',
       boxShadow: '0 2px 4px 0 rgba(0, 0, 0, 0.05)',
       ':hover, :focus, :active': {
@@ -96,7 +96,7 @@ const appearance = variant({
     tertiary: {
       ...sharedAppearance,
       bg: 'white',
-      color: 'primary',
+      color: `${theme.colors.primary} !important`,
       border: 'primary',
       ':hover, :focus, :active': {
         outline: 0,
@@ -108,7 +108,7 @@ const appearance = variant({
     error: {
       ...sharedAppearance,
       bg: 'white',
-      color: 'error',
+      color: `${theme.colors.error} !important`,
       border: 'error',
       boxShadow: '0px 2px 4px rgba(236, 56, 110, 0.05)',
       ':hover, :focus, :active': {

--- a/packages/ui/src/Button/index.tsx
+++ b/packages/ui/src/Button/index.tsx
@@ -76,7 +76,7 @@ const appearance = variant({
       ':hover, :focus, :active': {
         outline: 0,
         bg: '#494FCB',
-        color: 'white',
+        color: 'white !important',
         textDecoration: 'none',
       },
     },
@@ -88,7 +88,7 @@ const appearance = variant({
       boxShadow: '0 2px 4px 0 rgba(0, 0, 0, 0.05)',
       ':hover, :focus, :active': {
         outline: 0,
-        color: 'body',
+        color: `${theme.colors.body} !important`,
         boxShadow: '0 2px 4px 0 rgba(0, 0, 0, 0.1)',
         textDecoration: 'none',
       },
@@ -101,7 +101,7 @@ const appearance = variant({
       ':hover, :focus, :active': {
         outline: 0,
         bg: 'background',
-        color: 'primary',
+        color: `${theme.colors.primary} !important`,
         textDecoration: 'none',
       },
     },
@@ -115,7 +115,7 @@ const appearance = variant({
         outline: 0,
         boxShadow: '0px 2px 4px rgba(236, 56, 110, 0.15)',
         bg: 'background',
-        color: 'error',
+        color: `${theme.colors.error} !important`,
         textDecoration: 'none',
       },
     },


### PR DESCRIPTION
This aims to address:
- A problem first surfaced here: https://github.com/truework/truework-app/pull/1654
    - I added an additional Alert story to test this (saw that the dark navy color was showing before this change, whereas the specified button colors are showing now). 

- A few other bugs flagged by @lilldot:
    - https://trueworkhq.slack.com/archives/CQ254QABB/p1603751215015400 (I wasn't able to repro this one. Checking the code, the hover/focus state already specifies the white color for "primary" buttons.).

## Alternatives
This only seems to be happening when it is an anchor or Link button. I wonder if I should be going about this differently. Lmk!