### PR TITLE
remove uneeded moz specific css selector, test

### DIFF
--- a/packages/forms/src/Input.tsx
+++ b/packages/forms/src/Input.tsx
@@ -65,7 +65,6 @@ const InputElement = styled.input<InputProps>(
     }
   }
   &:invalid,
-  &:-moz-ui-invalid,
   &:not(:disabled):active,
   &:not(:disabled):focus,
   &:not(:disabled):hover {

--- a/packages/forms/src/stories.tsx
+++ b/packages/forms/src/stories.tsx
@@ -314,6 +314,9 @@ storiesOf('Formik', module).add('Basic', () => (
             name="select"
             label="Select"
             placeholder="Please select"
+            validate={val => {
+              return !val ? 'Required' : undefined;
+            }}
           >
             {[
               { value: 'one', label: 'One' },


### PR DESCRIPTION
This was breaking the `:focus` declaration in Safari, whoops. Added a validation in the Story to test Firefox error states.


<img width="669" alt="Screen Shot 2020-10-29 at 1 10 39 PM" src="https://user-images.githubusercontent.com/4732330/97614700-41ae9680-19e8-11eb-9e9f-e63551d04de1.png">
