### PR TITLE
Update Radio Component

### DIFF
--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -11,7 +11,7 @@ export type RadioProps = {
   name?: string;
   checked?: boolean;
   value: string;
-  itemDescription?: string;
+  itemDescription?: React.ReactNode;
   itemLabel: string;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 

--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -162,9 +162,10 @@ const RadioButton = styled.label<{ disabled?: boolean }>(
       transition-timing-function: ${theme.transitionTimingFunctions.ease};
     }
     
-    ${disabled
-      ? ``
-      : `
+    ${
+      disabled
+        ? ``
+        : `
           &:hover ${RadioItemLabel} {
             color: ${theme.colors.primary};
             transition-property: color;
@@ -199,8 +200,17 @@ export function Radio({
 
       <Check checked={checked} />
 
-      <Box display="block" zIndex={1} width="calc(100% - 32px)">
-        {itemLabel && <RadioItemLabel checked={checked} disabled={props.disabled}>{itemLabel}</RadioItemLabel>}
+      <Box
+        display="block"
+        position="relative"
+        zIndex={1}
+        width="calc(100% - 16px)"
+      >
+        {itemLabel && (
+          <RadioItemLabel checked={checked} disabled={props.disabled}>
+            {itemLabel}
+          </RadioItemLabel>
+        )}
         {itemDescription && (
           <P color="secondary" fontSize={0} fontWeight={0} lineHeight={0}>
             {itemDescription}

--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -20,21 +20,13 @@ export type RadioFieldProps = {
 } & Omit<RadioProps, 'checked' | 'value' | 'itemLabel'> &
   Pick<FieldConfig, 'validate'>;
 
-export type RadioFieldWithLabelProps = {
-  label: string;
-} & RadioFieldProps;
+export type RadioFieldWithLabelProps = { label: string } & RadioFieldProps;
 
-const RadioItemLabel = styled.span<{ checked?: boolean; disabled?: boolean }>(
-  ({ theme, checked, disabled }) => `
+const RadioItemLabel = styled.span(
+  ({ theme }) => `
   font-size: ${theme.fontSizes[0]};
   font-weight: ${theme.fontWeights[5]};
   line-height: ${theme.lineHeights[0]};
-
-  ${
-    disabled
-      ? `color: ${theme.colors.secondary};`
-      : `color: ${checked ? theme.colors.primary : theme.colors.body};`
-  }
 `
 );
 
@@ -115,9 +107,10 @@ const Input = styled.input(
     &:focus ~ ${Check} {
       border-color: ${theme.colors.primaryDark};
     }
-    &:focus ~ ${Box} ${RadioItemLabel} {
+    &:focus ~ ${Box} {
       color: ${theme.colors.primary};
     }
+
     &:checked ~ ${Check} {
       background: ${theme.colors.primary};
       border-color: ${theme.colors.primaryDark};
@@ -126,11 +119,18 @@ const Input = styled.input(
         transform: scale(1);
       }
     }
+    &:checked ~ ${Box} {
+      color: ${theme.colors.primary};
+    }
+
     &:disabled ~ ${Check} {
       border-color: ${theme.colors.outline} !important;
     }
     &:disabled ~ ${Bg} {
       background-color: ${theme.colors.background};
+    }
+    &:disabled ~ ${Box} {
+      color: ${theme.colors.secondary};
     }
   `
 );
@@ -145,8 +145,8 @@ const Bg = styled.span`
   z-index: 0;
 `;
 
-const RadioButton = styled.label<{ disabled?: boolean }>(
-  ({ theme, disabled }) => `
+const RadioButton = styled.label(
+  ({ theme }) => `
     display: flex;
     align-items: center;
     position: relative;
@@ -161,22 +161,15 @@ const RadioButton = styled.label<{ disabled?: boolean }>(
       transition-duration: ${theme.transitionDurations.fast};
       transition-timing-function: ${theme.transitionTimingFunctions.ease};
     }
-    
-    ${
-      disabled
-        ? ``
-        : `
-          &:hover ${RadioItemLabel} {
-            color: ${theme.colors.primary};
-            transition-property: color;
-            transition-duration: ${theme.transitionDurations.fast};
-            transition-timing-function: ${theme.transitionTimingFunctions.ease};
-          }
-        `
+
+    &:hover ${RadioItemLabel} {
+      color: ${theme.colors.primary};
+      transition-property: color;
+      transition-duration: ${theme.transitionDurations.fast};
+      transition-timing-function: ${theme.transitionTimingFunctions.ease};
     }
   `
 );
-
 
 export function Radio({
   children,
@@ -189,7 +182,7 @@ export function Radio({
   const id = name + props.value;
 
   return (
-    <RadioButton htmlFor={id} disabled={props.disabled}>
+    <RadioButton htmlFor={id}>
       <Input
         id={id}
         name={name}
@@ -206,11 +199,7 @@ export function Radio({
         zIndex={1}
         width="calc(100% - 16px)"
       >
-        {itemLabel && (
-          <RadioItemLabel checked={checked} disabled={props.disabled}>
-            {itemLabel}
-          </RadioItemLabel>
-        )}
+        {itemLabel && <RadioItemLabel>{itemLabel}</RadioItemLabel>}
         {itemDescription && (
           <P color="secondary" fontSize={0} fontWeight={0} lineHeight={0}>
             {itemDescription}

--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -24,10 +24,10 @@ export type RadioFieldWithLabelProps = { label: string } & RadioFieldProps;
 
 const RadioItemLabel = styled.span(
   ({ theme }) => `
-  font-size: ${theme.fontSizes[0]};
-  font-weight: ${theme.fontWeights[5]};
-  line-height: ${theme.lineHeights[0]};
-`
+    font-size: ${theme.fontSizes[0]};
+    font-weight: ${theme.fontWeights[5]};
+    line-height: ${theme.lineHeights[0]};
+  `
 );
 
 const RadioGroup = styled.div<{ hasError: boolean }>(

--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -22,7 +22,6 @@ export type RadioFieldProps = {
 
 export type RadioFieldWithLabelProps = {
   label: string;
-  description?: string;
 } & RadioFieldProps;
 
 const RadioItemLabel = styled.span<{ checked?: boolean; disabled?: boolean }>(
@@ -251,11 +250,6 @@ export function RadioFieldWithLabel(props: RadioFieldWithLabelProps) {
   return (
     <>
       <Label htmlFor={props.name}>{props.label}</Label>
-      {props.description && (
-        <P color="secondary" fontSize={0} fontWeight={0} lineHeight={0} my="xs">
-          {props.description}
-        </P>
-      )}
       <RadioField {...props} />
     </>
   );

--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { get } from 'lodash';
 import { Field, FieldProps, FieldConfig } from 'formik';
-import { Span } from '@truework/ui';
+import { Box, P } from '@truework/ui';
 
 import { Label } from './Label';
 
@@ -11,14 +11,33 @@ export type RadioProps = {
   name?: string;
   checked?: boolean;
   value: string;
+  itemDescription?: string;
+  itemLabel: string;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
 export type RadioFieldProps = {
   name: string;
-} & Omit<RadioProps, 'checked' | 'value'> &
+} & Omit<RadioProps, 'checked' | 'value' | 'itemLabel'> &
   Pick<FieldConfig, 'validate'>;
 
-export type RadioFieldWithLabelProps = { label: string } & RadioFieldProps;
+export type RadioFieldWithLabelProps = {
+  label: string;
+  description?: string;
+} & RadioFieldProps;
+
+const RadioItemLabel = styled.span<{ checked?: boolean; disabled?: boolean }>(
+  ({ theme, checked, disabled }) => `
+  font-size: ${theme.fontSizes[0]};
+  font-weight: ${theme.fontWeights[5]};
+  line-height: ${theme.lineHeights[0]};
+
+  ${
+    disabled
+      ? `color: ${theme.colors.secondary};`
+      : `color: ${checked ? theme.colors.primary : theme.colors.body};`
+  }
+`
+);
 
 const RadioGroup = styled.div<{ hasError: boolean }>(
   ({ theme, hasError }) => `
@@ -111,9 +130,6 @@ const Input = styled.input(
     &:disabled ~ ${Check} {
       border-color: ${theme.colors.outline} !important;
     }
-    &:disabled ~ ${Span} {
-      color: ${theme.colors.secondary};
-    }
     &:disabled ~ ${Bg} {
       background-color: ${theme.colors.background};
     }
@@ -130,8 +146,8 @@ const Bg = styled.span`
   z-index: 0;
 `;
 
-const RadioButton = styled.label(
-  ({ theme }) => `
+const RadioButton = styled.label<{ disabled?: boolean }>(
+  ({ theme, disabled }) => `
     display: flex;
     align-items: center;
     position: relative;
@@ -143,19 +159,31 @@ const RadioButton = styled.label(
     &:hover ${Check} {
       border-color: ${theme.colors.primaryDark};
     }
+    
+    ${disabled
+      ? ``
+      : `
+          &:hover ${RadioItemLabel} {
+            color: ${theme.colors.primary};
+          }
+        `
+    }
   `
 );
+
 
 export function Radio({
   children,
   name,
   checked,
+  itemDescription,
+  itemLabel,
   ...props
 }: RadioProps) {
   const id = name + props.value;
 
   return (
-    <RadioButton htmlFor={id}>
+    <RadioButton htmlFor={id} disabled={props.disabled}>
       <Input
         id={id}
         name={name}
@@ -166,9 +194,14 @@ export function Radio({
 
       <Check checked={checked} />
 
-      <Span display="block" position="relative" zIndex={1} width="calc(100% - 16px)" fontSize={1} lineHeight={1} fontWeight={5}>
-        {children}
-      </Span>
+      <Box display="block" zIndex={1} width="calc(100% - 32px)">
+        {itemLabel && <RadioItemLabel checked={checked} disabled={props.disabled}>{itemLabel}</RadioItemLabel>}
+        {itemDescription && (
+          <P color="secondary" fontSize={0} fontWeight={0} lineHeight={0}>
+            {itemDescription}
+          </P>
+        )}
+      </Box>
 
       <Bg />
     </RadioButton>
@@ -218,6 +251,11 @@ export function RadioFieldWithLabel(props: RadioFieldWithLabelProps) {
   return (
     <>
       <Label htmlFor={props.name}>{props.label}</Label>
+      {props.description && (
+        <P color="secondary" fontSize={0} fontWeight={0} lineHeight={0} my="xs">
+          {props.description}
+        </P>
+      )}
       <RadioField {...props} />
     </>
   );

--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -30,7 +30,6 @@ const RadioItemLabel = styled.span(
     transition-property: color;
     transition-duration: ${theme.transitionDurations.fast};
     transition-timing-function: ${theme.transitionTimingFunctions.ease};
-
   `
 );
 
@@ -74,7 +73,6 @@ const Check = styled.div<{ checked?: boolean }>(
     transition-property: background, border-color;
     transition-duration: ${theme.transitionDurations.fast};
     transition-timing-function: ${theme.transitionTimingFunctions.ease};
-
 
     &::after {
       content: '';
@@ -166,7 +164,6 @@ const RadioButton = styled.label(
     &:hover ${Check} {
       border-color: ${theme.colors.primaryDark};
     }
-
     &:hover ${RadioItemLabel} {
       color: ${theme.colors.primary};
     }

--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -75,9 +75,6 @@ const Check = styled.div<{ checked?: boolean }>(
     margin-right: 8px;
     border: 1px solid ${checked ? theme.colors.primaryDark : theme.colors.outline};
     z-index: 1;
-    transition-property: background, border-color;
-    transition-duration: ${theme.transitionDurations.fast};
-    transition-timing-function: ${theme.transitionTimingFunctions.ease};
 
     &::after {
       content: '';
@@ -118,6 +115,9 @@ const Input = styled.input(
     &:focus ~ ${Check} {
       border-color: ${theme.colors.primaryDark};
     }
+    &:focus ~ ${Box} ${RadioItemLabel} {
+      color: ${theme.colors.primary};
+    }
     &:checked ~ ${Check} {
       background: ${theme.colors.primary};
       border-color: ${theme.colors.primaryDark};
@@ -157,6 +157,9 @@ const RadioButton = styled.label<{ disabled?: boolean }>(
 
     &:hover ${Check} {
       border-color: ${theme.colors.primaryDark};
+      transition-property: border-color;
+      transition-duration: ${theme.transitionDurations.fast};
+      transition-timing-function: ${theme.transitionTimingFunctions.ease};
     }
     
     ${disabled
@@ -164,6 +167,9 @@ const RadioButton = styled.label<{ disabled?: boolean }>(
       : `
           &:hover ${RadioItemLabel} {
             color: ${theme.colors.primary};
+            transition-property: color;
+            transition-duration: ${theme.transitionDurations.fast};
+            transition-timing-function: ${theme.transitionTimingFunctions.ease};
           }
         `
     }

--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -24,9 +24,13 @@ export type RadioFieldWithLabelProps = { label: string } & RadioFieldProps;
 
 const RadioItemLabel = styled.span(
   ({ theme }) => `
-    font-size: ${theme.fontSizes[0]};
+    font-size: ${theme.fontSizes[1]};
     font-weight: ${theme.fontWeights[5]};
     line-height: ${theme.lineHeights[0]};
+    transition-property: color;
+    transition-duration: ${theme.transitionDurations.fast};
+    transition-timing-function: ${theme.transitionTimingFunctions.ease};
+
   `
 );
 
@@ -67,6 +71,10 @@ const Check = styled.div<{ checked?: boolean }>(
     margin-right: 8px;
     border: 1px solid ${checked ? theme.colors.primaryDark : theme.colors.outline};
     z-index: 1;
+    transition-property: background, border-color;
+    transition-duration: ${theme.transitionDurations.fast};
+    transition-timing-function: ${theme.transitionTimingFunctions.ease};
+
 
     &::after {
       content: '';
@@ -107,7 +115,7 @@ const Input = styled.input(
     &:focus ~ ${Check} {
       border-color: ${theme.colors.primaryDark};
     }
-    &:focus ~ ${Box} {
+    &:focus ~ ${Box} ${RadioItemLabel} {
       color: ${theme.colors.primary};
     }
 
@@ -119,7 +127,7 @@ const Input = styled.input(
         transform: scale(1);
       }
     }
-    &:checked ~ ${Box} {
+    &:checked ~ ${Box} ${RadioItemLabel} {
       color: ${theme.colors.primary};
     }
 
@@ -129,8 +137,8 @@ const Input = styled.input(
     &:disabled ~ ${Bg} {
       background-color: ${theme.colors.background};
     }
-    &:disabled ~ ${Box} {
-      color: ${theme.colors.secondary};
+    &:disabled ~ ${Box} ${RadioItemLabel} {
+      color: ${theme.colors.secondary} !important;
     }
   `
 );
@@ -157,16 +165,10 @@ const RadioButton = styled.label(
 
     &:hover ${Check} {
       border-color: ${theme.colors.primaryDark};
-      transition-property: border-color;
-      transition-duration: ${theme.transitionDurations.fast};
-      transition-timing-function: ${theme.transitionTimingFunctions.ease};
     }
 
     &:hover ${RadioItemLabel} {
       color: ${theme.colors.primary};
-      transition-property: color;
-      transition-duration: ${theme.transitionDurations.fast};
-      transition-timing-function: ${theme.transitionTimingFunctions.ease};
     }
   `
 );

--- a/packages/forms/src/stories.tsx
+++ b/packages/forms/src/stories.tsx
@@ -10,7 +10,7 @@ import { Input, InputFieldWithLabel } from './Input';
 import { Select, SelectFieldWithLabel } from './Select';
 import { Textarea, TextareaFieldWithLabel } from './Textarea';
 import { Checkbox, CheckboxField, CheckboxGroup } from './Checkbox';
-import {Radio, RadioField, RadioFieldWithLabel} from './Radio';
+import { Radio, RadioFieldWithLabel } from './Radio';
 import { Toggle, ToggleField } from './Toggle';
 import { DateInput, DateInputFieldWithLabel } from './DateInput';
 import { Dropdown, DropdownFieldWithLabel } from './Dropdown';
@@ -352,7 +352,6 @@ storiesOf('Formik', module).add('Basic', () => (
             <Radio value="baz" itemLabel="Item label for Baz" disabled itemDescription="Item description for Baz."/>
           </RadioFieldWithLabel>
         </Box>
-
         <Box mb="med" display="flex" alignItems="center">
           <ToggleField name="toggle" label="Toggle" />
           <Label mb="0" ml="xs">

--- a/packages/forms/src/stories.tsx
+++ b/packages/forms/src/stories.tsx
@@ -10,7 +10,7 @@ import { Input, InputFieldWithLabel } from './Input';
 import { Select, SelectFieldWithLabel } from './Select';
 import { Textarea, TextareaFieldWithLabel } from './Textarea';
 import { Checkbox, CheckboxField, CheckboxGroup } from './Checkbox';
-import { Radio, RadioFieldWithLabel } from './Radio';
+import {Radio, RadioField, RadioFieldWithLabel} from './Radio';
 import { Toggle, ToggleField } from './Toggle';
 import { DateInput, DateInputFieldWithLabel } from './DateInput';
 import { Dropdown, DropdownFieldWithLabel } from './Dropdown';
@@ -208,14 +208,10 @@ storiesOf('Base', module).add('Checkbox', () => (
 storiesOf('Base', module).add('Radio', () => (
   <Gutter withVertical>
     <Box mb="med">
-      <Radio name="a" value="a">
-        Radio
-      </Radio>
+      <Radio name="a" value="a" itemLabel="Radio"/>
     </Box>
     <Box mb="med">
-      <Radio name="b" value="b" checked>
-        Radio
-      </Radio>
+      <Radio name="b" value="b" checked itemLabel="Radio"/>
     </Box>
   </Gutter>
 ));
@@ -350,12 +346,13 @@ storiesOf('Formik', module).add('Basic', () => (
         </Box>
 
         <Box mb="med">
-          <RadioFieldWithLabel name="radio" label="Radio">
-            <Radio value="foo">Foo</Radio>
-            <Radio value="bar">Bar</Radio>
-            <Radio value="baz">Baz</Radio>
+          <RadioFieldWithLabel name="radio" label="Radio" description="This is a description for this group.">
+            <Radio value="foo" itemLabel="Item label for Foo" itemDescription="Item description for Foo."/>
+            <Radio value="bar" itemLabel="Item label for Bar" itemDescription="Item description for Bar."/>
+            <Radio value="baz" itemLabel="Item label for Baz" disabled itemDescription="Item description for Baz."/>
           </RadioFieldWithLabel>
         </Box>
+
         <Box mb="med" display="flex" alignItems="center">
           <ToggleField name="toggle" label="Toggle" />
           <Label mb="0" ml="xs">

--- a/packages/forms/src/stories.tsx
+++ b/packages/forms/src/stories.tsx
@@ -346,7 +346,7 @@ storiesOf('Formik', module).add('Basic', () => (
         </Box>
 
         <Box mb="med">
-          <RadioFieldWithLabel name="radio" label="Radio" description="This is a description for this group.">
+          <RadioFieldWithLabel name="radio" label="Radio">
             <Radio value="foo" itemLabel="Item label for Foo" itemDescription="Item description for Foo."/>
             <Radio value="bar" itemLabel="Item label for Bar" itemDescription="Item description for Bar."/>
             <Radio value="baz" itemLabel="Item label for Baz" disabled itemDescription="Item description for Baz."/>


### PR DESCRIPTION
In working on some new verifier teams settings (design here: https://www.figma.com/file/AzLrPomJ0891GTd6jD13bi/Verifier-Teams?node-id=1071%3A0), I saw a new pattern to Radio groups where, in addition to descriptions for individual radio options, we have a description for the whole group.

<img width="367" alt="Screen Shot 2020-11-09 at 4 32 27 PM" src="https://user-images.githubusercontent.com/59842325/98612515-2a559000-22a9-11eb-8d13-1d891282076e.png">

There were also a few other nice-to-haves that we were missing currently so I decided to make an update to our radio component here.

Changes:
- `label` and `description` for the entire group
- `itemLabel` (required) and `itemDescription` for individual options
- primary color on the item labels on hover
- primary color on the item labels if it is selected

### Screenshot from storybook:
<img width="533" alt="Screen Shot 2020-11-09 at 4 22 13 PM" src="https://user-images.githubusercontent.com/59842325/98613350-f4b1a680-22aa-11eb-9cc9-c4a2b4614017.png">
