### PR TITLE
Update Anchor

### DIFF
--- a/packages/ui/src/Anchor/index.tsx
+++ b/packages/ui/src/Anchor/index.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const A = styled.a(
   ({ theme }) => `
-    color: ${theme.colors.primary};
+    color: ${theme.colors.primary} !important;
     font-weight: ${theme.fontWeights[5]};
 
     &:hover {

--- a/packages/ui/src/Anchor/index.tsx
+++ b/packages/ui/src/Anchor/index.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
+import * as React from 'react';
 
-export const A = styled.a(
+const Anchor = styled.a(
   ({ theme }) => `
     color: ${theme.colors.primary} !important;
     font-weight: ${theme.fontWeights[5]};
@@ -10,3 +11,21 @@ export const A = styled.a(
     }
   `
 );
+
+export function A({
+  children,
+  href,
+  target,
+}: {
+  children: React.ReactChild;
+  href: string;
+  target?: '_blank' | '_parent' | '_self' | '_top';
+}) {
+  const t = target || '_blank';
+
+  return (
+    <Anchor href={href} target={t} rel="noopener noreferrer">
+      {children}
+    </Anchor>
+  );
+}

--- a/packages/ui/src/Anchor/index.tsx
+++ b/packages/ui/src/Anchor/index.tsx
@@ -15,16 +15,17 @@ const Anchor = styled.a(
 export function A({
   children,
   href,
-  target,
+  external,
 }: {
-  children: React.ReactChild;
+  children: React.ReactNode;
   href: string;
-  target?: '_blank' | '_parent' | '_self' | '_top';
+  external?: boolean;
 }) {
-  const t = target || '_blank';
-
   return (
-    <Anchor href={href} target={t} rel="noopener noreferrer">
+    <Anchor
+      href={href}
+      {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+    >
       {children}
     </Anchor>
   );

--- a/packages/ui/src/Anchor/index.tsx
+++ b/packages/ui/src/Anchor/index.tsx
@@ -13,16 +13,19 @@ const Anchor = styled.a(
 );
 
 export function A({
+  as = 'a',
   children,
   href,
   external,
 }: {
+  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
   children: React.ReactNode;
   href: string;
   external?: boolean;
 }) {
   return (
     <Anchor
+      as={as}
       href={href}
       {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
     >

--- a/packages/ui/src/Anchor/stories.tsx
+++ b/packages/ui/src/Anchor/stories.tsx
@@ -9,6 +9,8 @@ storiesOf('Link', module).add('All', () => (
     <H1 mb="xs">Link</H1>
     <P mb="lg">@components/Link</P>
 
-    <A href="https://truework.com">truework.com</A>
+    <A href="https://truework.com" external>
+      truework.com
+    </A>
   </Box>
 ));

--- a/packages/ui/src/Anchor/stories.tsx
+++ b/packages/ui/src/Anchor/stories.tsx
@@ -9,8 +9,6 @@ storiesOf('Link', module).add('All', () => (
     <H1 mb="xs">Link</H1>
     <P mb="lg">@components/Link</P>
 
-    <A href="https://truework.com" target="_blank" rel="noopener noreferrer">
-      truework.com
-    </A>
+    <A href="https://truework.com">truework.com</A>
   </Box>
 ));


### PR DESCRIPTION
Another update to prevent colors from being overwritten, this time in our anchor component.

Separately, Katherine recently asked if all external links open in a separate tab. It made me wonder if we could wrap `target='_blank'` by default in our anchor component. Happy to revert this if this isn't something we want to do.