### PR TITLE
fix type of itemLabel in Radio component

### DIFF
--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -11,13 +11,13 @@ export type RadioProps = {
   name?: string;
   checked?: boolean;
   value: string;
-  itemDescription?: React.ReactNode;
-  itemLabel: React.ReactNode;
+  description?: React.ReactNode;
+  label: React.ReactNode;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
 export type RadioFieldProps = {
   name: string;
-} & Omit<RadioProps, 'checked' | 'value' | 'itemLabel'> &
+} & Omit<RadioProps, 'checked' | 'value' | 'label'> &
   Pick<FieldConfig, 'validate'>;
 
 export type RadioFieldWithLabelProps = { label: string } & RadioFieldProps;
@@ -174,8 +174,8 @@ export function Radio({
   children,
   name,
   checked,
-  itemDescription,
-  itemLabel,
+  description,
+  label,
   ...props
 }: RadioProps) {
   const id = name + props.value;
@@ -198,10 +198,10 @@ export function Radio({
         zIndex={1}
         width="calc(100% - 16px)"
       >
-        {itemLabel && <RadioItemLabel>{itemLabel}</RadioItemLabel>}
-        {itemDescription && (
+        {label && <RadioItemLabel>{label}</RadioItemLabel>}
+        {description && (
           <P color="secondary" fontSize={0} fontWeight={0} lineHeight={0}>
-            {itemDescription}
+            {description}
           </P>
         )}
       </Box>
@@ -250,10 +250,13 @@ export function RadioField({
   );
 }
 
-export function RadioFieldWithLabel(props: RadioFieldWithLabelProps) {
+export function RadioFieldWithLabel({
+  label,
+  ...props
+}: RadioFieldWithLabelProps) {
   return (
     <>
-      <Label htmlFor={props.name}>{props.label}</Label>
+      <Label htmlFor={props.name}>{label}</Label>
       <RadioField {...props} />
     </>
   );

--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -12,7 +12,7 @@ export type RadioProps = {
   checked?: boolean;
   value: string;
   itemDescription?: React.ReactNode;
-  itemLabel: string;
+  itemLabel: React.ReactNode;
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
 export type RadioFieldProps = {

--- a/packages/forms/src/stories.tsx
+++ b/packages/forms/src/stories.tsx
@@ -347,7 +347,7 @@ storiesOf('Formik', module).add('Basic', () => (
 
         <Box mb="med">
           <RadioFieldWithLabel name="radio" label="Radio">
-            <Radio value="foo" itemLabel="Item label for Foo" itemDescription="Item description for Foo."/>
+            <Radio value="foo" itemLabel={<Span>Item label for Foo</Span>} itemDescription="Item description for Foo."/>
             <Radio value="bar" itemLabel="Item label for Bar" itemDescription="Item description for Bar."/>
             <Radio value="baz" itemLabel="Item label for Baz" disabled itemDescription="Item description for Baz."/>
           </RadioFieldWithLabel>

--- a/packages/forms/src/stories.tsx
+++ b/packages/forms/src/stories.tsx
@@ -208,10 +208,10 @@ storiesOf('Base', module).add('Checkbox', () => (
 storiesOf('Base', module).add('Radio', () => (
   <Gutter withVertical>
     <Box mb="med">
-      <Radio name="a" value="a" itemLabel="Radio"/>
+      <Radio name="a" value="a" label="Radio"/>
     </Box>
     <Box mb="med">
-      <Radio name="b" value="b" checked itemLabel="Radio"/>
+      <Radio name="b" value="b" checked label="Radio"/>
     </Box>
   </Gutter>
 ));
@@ -347,9 +347,9 @@ storiesOf('Formik', module).add('Basic', () => (
 
         <Box mb="med">
           <RadioFieldWithLabel name="radio" label="Radio">
-            <Radio value="foo" itemLabel={<Span>Item label for Foo</Span>} itemDescription="Item description for Foo."/>
-            <Radio value="bar" itemLabel="Item label for Bar" itemDescription="Item description for Bar."/>
-            <Radio value="baz" itemLabel="Item label for Baz" disabled itemDescription="Item description for Baz."/>
+            <Radio value="foo" label={<Span>Item label for Foo</Span>} description="Item description for Foo."/>
+            <Radio value="bar" label="Item label for Bar" description="Item description for Bar."/>
+            <Radio value="baz" label="Item label for Baz" disabled description="Item description for Baz."/>
           </RadioFieldWithLabel>
         </Box>
         <Box mb="med" display="flex" alignItems="center">


### PR DESCRIPTION
Updating the itemLabels to be of type React.ReactNode and made a small tweak in the story to test this.