### PR TITLE
Fix Radio description

### DIFF
--- a/packages/forms/src/Radio.tsx
+++ b/packages/forms/src/Radio.tsx
@@ -200,7 +200,7 @@ export function Radio({
       >
         {label && <RadioItemLabel>{label}</RadioItemLabel>}
         {description && (
-          <P color="secondary" fontSize={0} fontWeight={0} lineHeight={0}>
+          <P color="secondary" fontSize={0} fontWeight={4} lineHeight={0}>
             {description}
           </P>
         )}

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -134,7 +134,7 @@ export const fonts = {
  */
 export const fontSizes = ['12px', '14px', '16px', '18px', '21px', '32px'];
 export const lineHeights = ['16px', '20px', '24px', '24px', '24px', '40px'];
-export const fontWeights = [0, 100, 200, 300, 400, 500, 600, 700, 800, 900];
+export const fontWeights = [100, 100, 200, 300, 400, 500, 600, 700, 800, 900];
 
 export const space = {
   xxs: '4px',


### PR DESCRIPTION
Third time's the charm? 🤞 I had passed in the smallest font-weight for this description, but when trying to update truework-app, I saw that it was coming out bolded. After some investigation, it turns out that "0" isn't a valid value for font-weight. 

<img width="131" alt="Screen Shot 2020-11-11 at 4 30 58 PM" src="https://user-images.githubusercontent.com/59842325/98880082-c911f600-243b-11eb-8b19-18391b7a2055.png">
<img width="509" alt="Screen Shot 2020-11-11 at 4 30 44 PM" src="https://user-images.githubusercontent.com/59842325/98880079-c7483280-243b-11eb-9e3d-ae90be60adf4.png">

I update to font-weight: 400 here after checking designs. I wonder if we should update https://github.com/truework/ui/blob/0756459c16f1734d180aee5e2162b0d4142a2d8e/packages/ui/src/theme.ts#L137 to have 100 at index 0 as well?



