### PR TITLE
[Hackday] Add netlify config to enforce basic auth

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,0 +1,31 @@
+name: 'Netlify Previews'
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  deploy:
+    name: 'Deploy'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      # Sets the branch name as environment variable
+      - uses: nelonoel/branch-name@v1.0.1
+      - uses: jsmrcaga/action-netlify-deploy@master
+        with:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          deploy_alias: ${{ env.BRANCH_NAME }}
+
+      # Creates a status check with link to preview
+      - name: Status check
+        uses: Sibz/github-status-action@v1.1.1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: Netlify preview
+          state: success
+          target_url: https://${{ env.BRANCH_NAME }}--truework-ui.netlify.app

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 .cache
 dist
+.idea/
 
 .rts2_cache_cjs
 .rts2_cache_es

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  base = "."
+  publish = "storybook-static/"
+  command = "npm run build:storybook"
+
+[[headers]]
+  for = "*"
+
+  [headers.values]
+    Basic-Auth = "truework:zethos1234"


### PR DESCRIPTION
I've deployed storybook with netlify as a hackday project, and specified some settings via the netlify UI. 

But I'm thinking adding a netlify config file might be a better way to go about this: since this config file will override any settings made in the UI, it feels like a more secure way to manage these settings. Any changes made will require an update to this file, meaning a +1 from another person during PR review :) 

For now, I've just specified the build command and directory to publish (storybook-static), as well as basic authentication for anyone accessing this site.