### PR TITLE
feat(alert): add new alert variant

### DIFF
--- a/src/Alert/index.tsx
+++ b/src/Alert/index.tsx
@@ -11,6 +11,7 @@ export type AlertTypes =
   | 'error'
   | 'success'
   | 'secondary'
+  | 'image'
 
 export type AlertProps = {
   appearance: 'primary' | 'secondary'
@@ -123,6 +124,17 @@ const AlertOuter = styled.div<React.PropsWithChildren<AlertProps>>(
         },
         [AlertRight]: {
           color: 'successDark'
+        }
+      },
+      image: {
+        borderColor: 'primary',
+        display: 'flex',
+        alignItems: 'center',
+        [AlertLeft]: {
+          color: 'primary'
+        },
+        [AlertRight]: {
+          color: 'body'
         }
       }
     }

--- a/src/Alert/stories.tsx
+++ b/src/Alert/stories.tsx
@@ -75,5 +75,23 @@ storiesOf('Alerts', module).add('All', () => (
         </Button>
       </Box>
     </Alert>
+
+    <Alert
+      appearance='primary'
+      type='image'
+      mb='sm'
+      icon={<Icon name='FileText' width='60px' height='50px' />}
+    >
+      <Box display='flex' alignItems='center' justifyContent='space-between'>
+        <p>
+          <b>Going out of office?</b>
+          <br />
+          Truework Teams lets you share verifications with your teammates.
+        </p>
+        <Button as='a' href='#' appearance='tertiary' size='small'>
+          Request Team Account
+        </Button>
+      </Box>
+    </Alert>
   </Box>
 ))


### PR DESCRIPTION
Figma: https://www.figma.com/file/bVkQqrbnX5VUIE7pAXrb6Y/Verifier-Onboarding-2.0-Q2-2021?node-id=299%3A23662

For new teams upsells, looks like we'll need to add a new Alert variant without the background color on the left side.


## Screenshot
<img width="1049" alt="Screen Shot 2021-04-22 at 2 34 48 PM" src="https://user-images.githubusercontent.com/59842325/115788129-134abc00-a378-11eb-8773-72c4b458240d.png">
