### PR TITLE
fix(anchor): update anchor color

### DIFF
--- a/src/Anchor/index.tsx
+++ b/src/Anchor/index.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 export const A = styled.a(
   ({ theme }) => `
-    color: ${theme.colors.primary};
+    color: ${theme.colors.primary} !important;
     font-weight: ${theme.fontWeights[5]};
 
     &:hover {


### PR DESCRIPTION
Redoing what we tackled origin in #14 after pulling apart the monorepo.

This PR prevent colors from being overwritten in our anchor component.

~Separately, Katherine recently asked if all external links open in a separate tab, so we introduce an `external` prop that would handle this logic.~ Tackling this in a followup.